### PR TITLE
tweak(gameconfig): bump TxdStore pool by 30k

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -458,7 +458,7 @@
 						</Item>
 						<Item>
 							<PoolName>TxdStore</PoolName>
-							<PoolSize value="105500"/>
+							<PoolSize value="135500"/>
 						</Item>
 						<Item>
 							<PoolName>CNetObjVehicle</PoolName>


### PR DESCRIPTION
### Goal of this PR
Each game DLC further decreases the amount of streamed YTDs a server can have. This particularly affects servers with a lot of maps or clothing. Ideally it would be great for work to finish on [#1419](https://github.com/citizenfx/fivem/pull/1419) however bumping this value would suffice as a temporary measure. 

### How is this PR achieving the goal

By bumping the pool limit by 30k, it gives some breathing room for servers with a lot of streamed clothing for the next couple DLCs.


### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


